### PR TITLE
feat(search): replace inline dropdown with results page

### DIFF
--- a/public/search-data.json
+++ b/public/search-data.json
@@ -30,6 +30,11 @@
     "content": "quotes Words worth keeping. A curated collection of literary wisdom."
   },
   {
+    "url": "/search",
+    "title": "search",
+    "content": "search"
+  },
+  {
     "url": "/til",
     "title": "til",
     "content": "til Today I learned. Short notes. No fluff."

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -1,7 +1,6 @@
-<div class="search-container">
-  <input type="search" id="search-input" placeholder="ctrl-k" aria-label="Search" />
-  <div id="search-results" class="search-results" hidden></div>
-</div>
+<form class="search-container" action="/search" method="get" role="search">
+  <input type="search" id="search-input" name="q" placeholder="ctrl-k" aria-label="Search" />
+</form>
 
 <style>
   .search-container {
@@ -34,167 +33,14 @@
   #search-input::placeholder {
     color: var(--color-text-muted);
   }
-
-  .search-results {
-    position: absolute;
-    top: calc(100% + var(--spacing-xs));
-    left: 0;
-    min-width: 500px;
-    background-color: var(--color-bg);
-    border: var(--border-width) solid var(--color-accent);
-    max-height: 500px;
-    overflow-y: auto;
-    z-index: var(--z-index-dropdown);
-  }
-
-  @media (max-width: 768px) {
-    .search-results {
-      min-width: 100%;
-      max-width: calc(100vw - var(--spacing-md));
-      left: calc(var(--spacing-sm) * -1);
-    }
-  }
-
-  .search-results[hidden] {
-    display: none;
-  }
-
-  .search-result-item {
-    padding: var(--spacing-md);
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .search-result-item:last-child {
-    border-bottom: none;
-  }
-
-  .search-result-item:hover {
-    background-color: var(--color-til-hover);
-  }
-
-  .search-result-item a {
-    text-decoration: none;
-    display: block;
-  }
-
-  .search-result-title {
-    color: var(--color-accent);
-    margin-bottom: var(--spacing-xs);
-    font-size: 1rem;
-    font-weight: 600;
-  }
-
-  .search-result-excerpt {
-    font-size: 0.9rem;
-    color: var(--color-text);
-    line-height: 1.5;
-  }
-
-  .search-no-results {
-    padding: var(--spacing-sm);
-    color: var(--color-text-muted);
-    text-align: center;
-  }
 </style>
 
 <script>
-  const searchInput = document.getElementById("search-input") as HTMLInputElement
-  const searchResults = document.getElementById("search-results") as HTMLDivElement
-
-  interface PageData {
-    url: string
-    title: string
-    content: string
-  }
-
-  let pagesData: PageData[] = []
-
-  async function loadPagesData() {
-    try {
-      const response = await fetch("/search-data.json")
-      pagesData = await response.json()
-    } catch (error) {
-      console.error("Failed to load search data:", error)
-    }
-  }
-
-  function search(query: string): PageData[] {
-    if (!query || query.length < 2) return []
-
-    const lowerQuery = query.toLowerCase()
-    return pagesData
-      .filter(
-        page =>
-          page.title.toLowerCase().includes(lowerQuery) ||
-          page.content.toLowerCase().includes(lowerQuery)
-      )
-      .slice(0, 5)
-  }
-
-  function getExcerpt(content: string, query: string): string {
-    const lowerContent = content.toLowerCase()
-    const lowerQuery = query.toLowerCase()
-    const index = lowerContent.indexOf(lowerQuery)
-
-    if (index === -1) return content.slice(0, 150) + "..."
-
-    const start = Math.max(0, index - 80)
-    const end = Math.min(content.length, index + query.length + 80)
-
-    let excerpt = content.slice(start, end)
-    if (start > 0) excerpt = "..." + excerpt
-    if (end < content.length) excerpt = excerpt + "..."
-
-    return excerpt
-  }
-
-  function displayResults(results: PageData[], query: string) {
-    if (results.length === 0) {
-      searchResults.innerHTML = '<div class="search-no-results">no results found</div>'
-      searchResults.hidden = false
-      return
-    }
-
-    searchResults.innerHTML = results
-      .map(
-        page => `
-        <div class="search-result-item">
-          <a href="${page.url}">
-            <div class="search-result-title">${page.title}</div>
-            <div class="search-result-excerpt">${getExcerpt(page.content, query)}</div>
-          </a>
-        </div>
-      `
-      )
-      .join("")
-
-    searchResults.hidden = false
-  }
-
-  searchInput?.addEventListener("input", e => {
-    const query = (e.target as HTMLInputElement).value
-
-    if (!query || query.length < 2) {
-      searchResults.hidden = true
-      return
-    }
-
-    const results = search(query)
-    displayResults(results, query)
-  })
+  const searchInput = document.getElementById("search-input") as HTMLInputElement | null
 
   searchInput?.addEventListener("keydown", e => {
     if (e.key === "Escape") {
       searchInput.blur()
-      searchResults.hidden = true
     }
   })
-
-  document.addEventListener("click", e => {
-    if (!searchInput?.contains(e.target as Node) && !searchResults?.contains(e.target as Node)) {
-      searchResults.hidden = true
-    }
-  })
-
-  loadPagesData()
 </script>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,0 +1,188 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro"
+---
+
+<BaseLayout title="search - wtfm">
+  <article>
+    <h1>search</h1>
+
+    <form id="search-form" action="/search" method="get" role="search" class="search-page-form">
+      <input
+        type="search"
+        id="search-page-input"
+        name="q"
+        placeholder="type and press enter..."
+        aria-label="Search"
+        autofocus
+      />
+    </form>
+
+    <p id="search-summary" class="summary"></p>
+    <div id="search-results" class="results"></div>
+  </article>
+</BaseLayout>
+
+<style>
+  h1 {
+    margin-bottom: var(--spacing-md);
+    text-transform: lowercase;
+  }
+
+  .search-page-form {
+    margin-bottom: var(--spacing-md);
+  }
+
+  #search-page-input {
+    width: 100%;
+    background-color: var(--color-bg);
+    border: 1px solid var(--color-border);
+    color: var(--color-text);
+    font-family: var(--font-mono);
+    font-size: 1rem;
+    padding: 0.6rem 0.85rem;
+    outline: none;
+  }
+
+  #search-page-input:focus {
+    border-color: var(--color-accent);
+  }
+
+  .summary {
+    color: var(--color-text-muted);
+    font-size: 0.9rem;
+    margin-bottom: var(--spacing-md);
+  }
+
+  .results {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+  }
+
+  .result-item {
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: var(--spacing-md);
+  }
+
+  .result-item:last-child {
+    border-bottom: none;
+  }
+
+  .result-item a {
+    text-decoration: none;
+  }
+
+  .result-item a:hover .result-title {
+    text-decoration: underline;
+  }
+
+  .result-title {
+    color: var(--color-accent);
+    font-size: 1.1rem;
+    font-weight: 500;
+    margin-bottom: var(--spacing-xs);
+  }
+
+  .result-url {
+    color: var(--color-text-muted);
+    font-size: 0.8rem;
+    margin-bottom: var(--spacing-xs);
+    font-family: var(--font-mono);
+  }
+
+  .result-excerpt {
+    color: var(--color-text);
+    font-size: 0.9rem;
+    line-height: 1.6;
+  }
+
+  .result-excerpt :global(mark) {
+    background-color: var(--color-accent);
+    color: var(--color-bg);
+    padding: 0 2px;
+  }
+</style>
+
+<script>
+  interface PageData {
+    url: string
+    title: string
+    content: string
+  }
+
+  const params = new URLSearchParams(window.location.search)
+  const query = (params.get("q") || "").trim()
+  const input = document.getElementById("search-page-input") as HTMLInputElement
+  const summary = document.getElementById("search-summary") as HTMLParagraphElement
+  const resultsEl = document.getElementById("search-results") as HTMLDivElement
+
+  if (input && query) input.value = query
+
+  function escapeHtml(s: string): string {
+    return s
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;")
+  }
+
+  function highlight(text: string, q: string): string {
+    const safe = escapeHtml(text)
+    if (!q) return safe
+    const re = new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "ig")
+    return safe.replace(re, m => `<mark>${m}</mark>`)
+  }
+
+  function getExcerpt(content: string, q: string): string {
+    const lc = content.toLowerCase()
+    const lq = q.toLowerCase()
+    const i = lc.indexOf(lq)
+    if (i === -1) return content.slice(0, 200) + "..."
+    const start = Math.max(0, i - 100)
+    const end = Math.min(content.length, i + q.length + 100)
+    let ex = content.slice(start, end)
+    if (start > 0) ex = "..." + ex
+    if (end < content.length) ex = ex + "..."
+    return ex
+  }
+
+  async function run() {
+    if (!query || query.length < 2) {
+      summary.textContent = query ? "type at least 2 characters." : "enter a query above."
+      return
+    }
+
+    let pages: PageData[] = []
+    try {
+      const res = await fetch("/search-data.json")
+      pages = await res.json()
+    } catch (e) {
+      summary.textContent = "failed to load search index."
+      return
+    }
+
+    const lq = query.toLowerCase()
+    const results = pages.filter(
+      p => p.title.toLowerCase().includes(lq) || p.content.toLowerCase().includes(lq)
+    )
+
+    summary.textContent = `${results.length} result${results.length === 1 ? "" : "s"} for "${query}"`
+
+    resultsEl.innerHTML = results
+      .map(
+        p => `
+        <div class="result-item">
+          <a href="${p.url}">
+            <div class="result-title">${highlight(p.title, query)}</div>
+            <div class="result-url">${p.url}</div>
+            <div class="result-excerpt">${highlight(getExcerpt(p.content, query), query)}</div>
+          </a>
+        </div>
+      `
+      )
+      .join("")
+  }
+
+  run()
+</script>


### PR DESCRIPTION
Header search submits to /search?q=... and shows a full page of results with excerpts and highlighted matches.