### PR TITLE
feat(ui): soften palette, add copy buttons, polish details

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -299,6 +299,40 @@ const { title, description = "Write the Fucking Manual - A minimalist guide to d
         }
       })
       ;(window as any).showNotification = showNotification
+
+      function addCopyButtons() {
+        document.querySelectorAll<HTMLElement>("pre").forEach(pre => {
+          if (pre.querySelector(".copy-button")) return
+          const btn = document.createElement("button")
+          btn.type = "button"
+          btn.className = "copy-button"
+          btn.textContent = "copy"
+          btn.setAttribute("aria-label", "copy code to clipboard")
+          btn.addEventListener("click", async e => {
+            e.preventDefault()
+            const code = pre.querySelector("code")
+            const text = (code?.innerText ?? pre.innerText).replace(/copy$/, "").trimEnd()
+            try {
+              await navigator.clipboard.writeText(text)
+              btn.textContent = "copied"
+              btn.classList.add("copied")
+              setTimeout(() => {
+                btn.textContent = "copy"
+                btn.classList.remove("copied")
+              }, 1500)
+            } catch (err) {
+              console.error("copy failed", err)
+            }
+          })
+          pre.appendChild(btn)
+        })
+      }
+
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", addCopyButtons)
+      } else {
+        addCopyButtons()
+      }
     </script>
   </body>
 </html>

--- a/src/pages/posts.astro
+++ b/src/pages/posts.astro
@@ -131,9 +131,12 @@ function formatDate(dateString: string): string {
 
   .post-entry h2 a {
     text-decoration: none;
+    color: var(--color-text);
+    transition: color 0.2s ease;
   }
 
   .post-entry h2 a:hover {
+    color: var(--color-accent);
     text-decoration: underline;
   }
 

--- a/src/pages/til.astro
+++ b/src/pages/til.astro
@@ -112,25 +112,28 @@ const sortedTils = tils.sort((a, b) => {
     bottom: 0;
     width: 1px;
     background-color: var(--color-border);
+    opacity: 0.5;
   }
 
   .tl-pipe::after {
     content: "";
     position: absolute;
     top: calc(var(--spacing-md) + 0.1rem);
-    width: 13px;
-    height: 13px;
+    width: 11px;
+    height: 11px;
     border: 1px solid var(--color-border);
     background-color: var(--color-bg);
     border-radius: 50%;
     transition:
       border-color 0.2s,
-      background-color 0.2s;
+      background-color 0.2s,
+      box-shadow 0.2s;
   }
 
   .tl-pipe:hover::after {
     border-color: var(--color-accent);
     background-color: var(--color-accent);
+    box-shadow: 0 0 6px 1px var(--color-accent);
   }
 
   .tl-entry:first-child .tl-pipe::before {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,24 +7,24 @@
 }
 
 :root {
-  --color-bg: #0a0a0a;
-  --color-bg-secondary: rgba(26, 26, 26, 0.5);
-  --color-text: #d0d0d0;
-  --color-text-muted: #808080;
-  --color-accent: #2ec42e;
-  --color-accent-hover: #3fd93f;
-  --color-border: #2a2a2a;
-  --color-pre-bg: #111111;
-  --color-pre-border: #2ec42e;
+  --color-bg: #161616;
+  --color-bg-secondary: rgba(40, 40, 40, 0.5);
+  --color-text: #e0e0e0;
+  --color-text-muted: #909090;
+  --color-accent: #b8bb26;
+  --color-accent-hover: #d6d960;
+  --color-border: #2e2e2e;
+  --color-pre-bg: #1d1d1d;
+  --color-pre-border: #b8bb26;
   --color-pre-text: #e0e0e0;
-  --color-til-bg: rgba(26, 26, 26, 0.3);
-  --color-til-hover: rgba(46, 196, 46, 0.05);
+  --color-til-bg: rgba(40, 40, 40, 0.3);
+  --color-til-hover: rgba(184, 187, 38, 0.06);
   --spacing-xs: 0.25rem;
   --spacing-sm: 0.5rem;
   --spacing-md: 1rem;
   --spacing-lg: 1.5rem;
   --spacing-xl: 2.5rem;
-  --max-width: 72ch;
+  --max-width: 70ch;
   --font-mono:
     "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas, "Courier New", monospace;
   --z-index-skip-link: 100;
@@ -40,21 +40,21 @@
   --color-bg: #fafafa;
   --color-bg-secondary: rgba(220, 220, 220, 0.5);
   --color-text: #2a2a2a;
-  --color-text-muted: #707070;
-  --color-accent: #2ec42e;
-  --color-accent-hover: #25a025;
+  --color-text-muted: #6a6a6a;
+  --color-accent: #79740e;
+  --color-accent-hover: #5c570a;
   --color-border: #e0e0e0;
-  --color-pre-bg: #fafafa;
-  --color-pre-border: #2ec42e;
+  --color-pre-bg: #f1f1f1;
+  --color-pre-border: #79740e;
   --color-pre-text: #2a2a2a;
   --color-til-bg: transparent;
-  --color-til-hover: rgba(46, 196, 46, 0.08);
+  --color-til-hover: rgba(121, 116, 14, 0.08);
 }
 
 html {
   font-family: var(--font-mono);
   font-size: 1.05rem;
-  line-height: 1.65;
+  line-height: 1.7;
   color: var(--color-text);
   background-color: var(--color-bg);
   overflow-y: scroll;
@@ -96,10 +96,10 @@ h1 {
 }
 
 h2 {
-  font-size: 1.8rem;
+  font-size: 1.6rem;
   font-weight: 600;
-  margin-top: 1.75rem;
-  margin-bottom: 0.75rem;
+  margin-top: var(--spacing-xl);
+  margin-bottom: var(--spacing-md);
   color: var(--color-accent);
 }
 
@@ -198,10 +198,46 @@ pre {
   border-top: 1px solid var(--color-border);
   border-bottom: 1px solid var(--color-border);
   overflow-x: auto;
-  margin-top: -0.25rem;
-  margin-bottom: 0.5rem;
-  line-height: 1.55;
+  margin-top: var(--spacing-sm);
+  margin-bottom: var(--spacing-lg);
+  line-height: 1.6;
   max-width: 100%;
+  position: relative;
+}
+
+.copy-button {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+  background: transparent;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  padding: 0.15rem 0.5rem;
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+pre:hover .copy-button {
+  opacity: 1;
+}
+
+.copy-button:hover,
+.copy-button:focus-visible {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+  outline: none;
+}
+
+.copy-button.copied {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+  opacity: 1;
 }
 
 pre + pre {


### PR DESCRIPTION
Visual pass:

- Less aggressive palette (gruvbox-style green, off-black bg, off-white text)
- Wider air: line-height 1.7, narrower content column
- Code blocks: copy button on hover
- Post titles: only green on hover, calmer list
- TIL timeline: subtler line, glowing dot on hover